### PR TITLE
Cleaned up import statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@folio/stripes-components": "^3.1.0",
     "@folio/stripes-connect": "^3.2.0",
-    "@folio/stripes-smart-components": "^1.7.1",
+    "@folio/stripes-smart-components": "^1.8.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react-router-dom": "^4.1.1"

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Button from '@folio/stripes-components/lib/Button';
-import SegmentedControl from '@folio/stripes-components/lib/SegmentedControl';
+import { Button, SegmentedControl } from '@folio/stripes-components';
 
-import css from './Tabs.css'
+import css from './Tabs.css';
 
 export default class Tabs extends React.Component {
   static propTypes = {

--- a/src/components/ViewAgreement/Sections/AgreementInfo.js
+++ b/src/components/ViewAgreement/Sections/AgreementInfo.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion, AccordionSet } from '@folio/stripes-components/lib/Accordion';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
-import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
+import {
+  Accordion,
+  AccordionSet,
+  Col,
+  KeyValue,
+  Row,
+} from '@folio/stripes-components';
 
 import css from './AgreementInfo.css';
 

--- a/src/components/ViewAgreement/Sections/AgreementLines.js
+++ b/src/components/ViewAgreement/Sections/AgreementLines.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion } from '@folio/stripes-components/lib/Accordion';
-import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
-import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
+import {
+  Accordion,
+  Col,
+  MultiColumnList,
+  Row,
+} from '@folio/stripes-components';
 
 class AgreementLines extends React.Component {
   static propTypes = {

--- a/src/components/ViewAgreement/Sections/AssociatedAgreements.js
+++ b/src/components/ViewAgreement/Sections/AssociatedAgreements.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion, AccordionSet } from '@folio/stripes-components/lib/Accordion';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
-import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
+import { Accordion } from '@folio/stripes-components';
 
 class AssociatedAgreements extends React.Component {
   static propTypes = {

--- a/src/components/ViewAgreement/Sections/Eresources.js
+++ b/src/components/ViewAgreement/Sections/Eresources.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion, AccordionSet } from '@folio/stripes-components/lib/Accordion';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
-import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
+import { Accordion } from '@folio/stripes-components';
 
 class Eresources extends React.Component {
   static propTypes = {

--- a/src/components/ViewAgreement/Sections/License.js
+++ b/src/components/ViewAgreement/Sections/License.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion, AccordionSet } from '@folio/stripes-components/lib/Accordion';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
-import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
+import { Accordion } from '@folio/stripes-components';
 
 class License extends React.Component {
   static propTypes = {

--- a/src/components/ViewAgreement/Sections/LicenseBusinessTerms.js
+++ b/src/components/ViewAgreement/Sections/LicenseBusinessTerms.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion, AccordionSet } from '@folio/stripes-components/lib/Accordion';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
-import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
+import { Accordion } from '@folio/stripes-components';
 
 class LicenseBusinessTerms extends React.Component {
   static propTypes = {

--- a/src/components/ViewAgreement/Sections/Organizations.js
+++ b/src/components/ViewAgreement/Sections/Organizations.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion, AccordionSet } from '@folio/stripes-components/lib/Accordion';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
-import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
+import { Accordion } from '@folio/stripes-components';
 
 class Organizations extends React.Component {
   static propTypes = {

--- a/src/components/ViewAgreement/ViewAgreement.js
+++ b/src/components/ViewAgreement/ViewAgreement.js
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
-import { AccordionSet, Accordion } from '@folio/stripes-components/lib/Accordion';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
-import Layout from '@folio/stripes-components/lib/Layout';
-import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
-import Icon from '@folio/stripes-components/lib/Icon';
-import Pane from '@folio/stripes-components/lib/Pane';
+import {
+  AccordionSet,
+  Icon,
+  Layout,
+  Pane,
+} from '@folio/stripes-components';
 
 import {
   AgreementInfo,

--- a/src/components/ViewKB/ViewKB.js
+++ b/src/components/ViewKB/ViewKB.js
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
-import Layout from '@folio/stripes-components/lib/Layout';
-import Icon from '@folio/stripes-components/lib/Icon';
-import Pane from '@folio/stripes-components/lib/Pane';
+import {
+  Icon,
+  Layout,
+  Pane,
+} from '@folio/stripes-components';
 
 export default class ViewKB extends React.Component {
   static manifest = Object.freeze({

--- a/src/components/ViewTitle/ViewTitle.js
+++ b/src/components/ViewTitle/ViewTitle.js
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
-import Layout from '@folio/stripes-components/lib/Layout';
-import Icon from '@folio/stripes-components/lib/Icon';
-import Pane from '@folio/stripes-components/lib/Pane';
+import {
+  Icon,
+  Layout,
+  Pane,
+} from '@folio/stripes-components';
 
 export default class ViewTitle extends React.Component {
   static manifest = Object.freeze({

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import SearchAndSort from '@folio/stripes-smart-components/lib/SearchAndSort';
+import { SearchAndSort } from '@folio/stripes-smart-components';
 
 import ViewAgreement from '../components/ViewAgreement';
 import packageInfo from '../../package.json';

--- a/src/routes/KBs.js
+++ b/src/routes/KBs.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
-import SearchAndSort from '@folio/stripes-smart-components/lib/SearchAndSort';
+import { SearchAndSort } from '@folio/stripes-smart-components';
 
 import ViewKB from '../components/ViewKB';
 import packageInfo from '../../package.json';

--- a/src/routes/Titles.js
+++ b/src/routes/Titles.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import SearchAndSort from '@folio/stripes-smart-components/lib/SearchAndSort';
+import { SearchAndSort } from '@folio/stripes-smart-components';
 
 import ViewTitle from '../components/ViewTitle';
 import packageInfo from '../../package.json';


### PR DESCRIPTION
Switched to using the top-level imports for Stripes modules as a result of the work in https://github.com/folio-org/stripes-smart-components/pull/256