### PR TITLE
Fixed paging requests for /titles

### DIFF
--- a/src/ERM.js
+++ b/src/ERM.js
@@ -9,7 +9,10 @@ import Titles from './routes/Titles';
 import Tabs from './components/Tabs';
 
 export default class Erm extends React.Component {
-  static manifest = Object.freeze({ query: {} });
+  static manifest = Object.freeze({
+    query: {},
+    resultCount: {},
+  });
 
   static propTypes = {
     location: PropTypes.shape({

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -25,18 +25,13 @@ export default class Tabs extends React.Component {
   setTab = () => {
     const { tab } = this.props;
     if (!tab) return;
-    this.setState( { tab })
+    this.setState({ tab });
   }
 
   handleActivate = ({ id }) => {
     this.setState({ tab: id });
-    this.props.parentMutator.query.update({
-      _path: `/erm/${id}`,
-      layer: null,
-      query: '',
-      filters: '',
-      sort: '',
-    });
+    this.props.parentMutator.query.replace({ _path: `/erm/${id}` });
+    this.props.parentMutator.resultCount.replace(1);
   }
 
   render() {

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import { SearchAndSort } from '@folio/stripes-smart-components';
 
 import ViewAgreement from '../components/ViewAgreement';
-import packageInfo from '../../package.json';
+import packageInfo from '../../package';
 
-const INITIAL_RESULT_COUNT = 20;
+const INITIAL_RESULT_COUNT = 100;
 
 const EditRecord = (props) => (
   <div>
@@ -44,7 +44,7 @@ export default class Agreements extends React.Component {
       },
     },
     query: {},
-    resultCount: { initialValue: INITIAL_RESULT_COUNT },
+    resultCount: { },
   });
 
   static propTypes = {

--- a/src/routes/KBs.js
+++ b/src/routes/KBs.js
@@ -5,9 +5,9 @@ import { get } from 'lodash';
 import { SearchAndSort } from '@folio/stripes-smart-components';
 
 import ViewKB from '../components/ViewKB';
-import packageInfo from '../../package.json';
+import packageInfo from '../../package';
 
-const INITIAL_RESULT_COUNT = 20;
+const INITIAL_RESULT_COUNT = 100;
 
 const EditRecord = (props) => (
   <div>
@@ -42,7 +42,7 @@ export default class KBs extends React.Component {
       },
     },
     query: {},
-    resultCount: { initialValue: INITIAL_RESULT_COUNT },
+    resultCount: { },
   });
 
   static propTypes = {

--- a/src/routes/Titles.js
+++ b/src/routes/Titles.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import { SearchAndSort } from '@folio/stripes-smart-components';
 
 import ViewTitle from '../components/ViewTitle';
-import packageInfo from '../../package.json';
+import packageInfo from '../../package';
 
-const INITIAL_RESULT_COUNT = 1;
+const INITIAL_RESULT_COUNT = 100;
 
 const EditRecord = (props) => (
   <div>
@@ -25,12 +25,10 @@ export default class Titles extends React.Component {
       records: 'results',
       path: 'erm/titles',
       recordsRequired: '%{resultCount}',
-      perRequest: 1,
-      offsetParam: 'page',
+      perRequest: 100,
       GET: {
         params: (queryParams, pathComponents, resources) => {
           const params = {
-            perPage: '100',
             stats: 'true',
           };
 
@@ -57,6 +55,10 @@ export default class Titles extends React.Component {
   static propTypes = {
     resources: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
+      resultCount: PropTypes.number,
+    }),
+    mutator: PropTypes.shape({
+      resultCount: PropTypes.object,
     }),
   };
 


### PR DESCRIPTION
Paging was busted on the Titles route because:

- It kept paging up and up without end, past page 102 etc.
- The first two pages were the same.

Fixed it by:

- Resetting the `resultCount` when navigating to a new page via Tabs.
- Using the `offset` rather than `page` parameter.