### PR TITLE
Switched to using string-type paths for manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@folio/stripes-smart-components": "^1.8.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
+    "react-intl": "^2.4.0",
     "react-router-dom": "^4.1.1",
     "redux-form": "^7.0.3"
   },

--- a/src/components/Agreements/ViewAgreement/Sections/AgreementLines.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AgreementLines.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { injectIntl, intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
 import {
   Accordion,
@@ -13,11 +14,11 @@ class AgreementLines extends React.Component {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    stripes: PropTypes.object,
+    intl: intlShape,
   };
 
   render() {
-    const { agreementLines, stripes: { intl } } = this.props;
+    const { agreementLines, intl } = this.props;
 
     return (
       <Accordion
@@ -36,6 +37,10 @@ class AgreementLines extends React.Component {
                 name: line => line.entitlementLabel,
                 type: line => line.entitlementType,
               }}
+              columnMapping={{
+                name: intl.formatMessage({ id: 'ui-erm.agreementLines.name' }),
+                type: intl.formatMessage({ id: 'ui-erm.agreementLines.type' }),
+              }}
               columnWidths={{
                 name: '50%',
                 type: '50%',
@@ -48,4 +53,4 @@ class AgreementLines extends React.Component {
   }
 }
 
-export default AgreementLines;
+export default injectIntl(AgreementLines);

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -13,19 +13,22 @@ class Agreements extends React.Component {
   static manifest = Object.freeze({
     records: {
       type: 'okapi',
+      path: 'erm/sas',
       resourceShouldRefresh: true,
       records: 'results',
-      path: (queryParams, pathComponents, resources) => {
-        const path = 'erm/sas';
-        const params = ['stats=true'];
+      params: (queryParams, pathComponents, resources) => {
+        const params = {
+          stats: 'true',
+        };
 
         const { query: { query, filters, sort } } = resources;
 
-        if (query) params.push(`match=name&match=description&term=${query}`);
+        if (query) {
+          params.match = ['name', 'description'];
+          params.term = query;
+        }
 
-        if (params.length) return `${path}?${params.join('&')}`;
-
-        return path;
+        return params;
       },
     },
     query: {},

--- a/src/routes/KBs.js
+++ b/src/routes/KBs.js
@@ -18,27 +18,26 @@ const EditRecord = (props) => (
   </div>
 );
 
-const MATCH = [
-  'pti.titleInstance.title'
-].map(t => `match=${t}`).join('&');
-
 export default class KBs extends React.Component {
   static manifest = Object.freeze({
     records: {
+      path: 'erm/pci',
       type: 'okapi',
       resourceShouldRefresh: true,
       records: 'results',
-      path: (queryParams, pathComponents, resources) => {
-        const path = 'erm/pci';
-        const params = ['stats=true'];
+      params: (queryParams, pathComponents, resources) => {
+        const params = {
+          stats: 'true',
+        };
 
         const { query: { query, filters, sort } } = resources;
 
-        if (query) params.push(`${MATCH}&term=${query}`);
+        if (query) {
+          params.match = 'pti.titleInstance.title';
+          params.term = query;
+        }
 
-        if (params.length) return `${path}?${params.join('&')}`;
-
-        return path;
+        return params;
       },
     },
     query: {},

--- a/translations/ui-erm/en.json
+++ b/translations/ui-erm/en.json
@@ -1,15 +1,5 @@
 {
   "meta.title": "ERM",
-  "new-app.greeting": "Congratulations!",
-  "new-app.message": "Your Stripes app is running.",
-
-  "settings.general": "General",
-  "settings.general.message": "These are your general app settings.",
-  "settings.some-feature": "Some Feature",
-  "settings.some-feature.message": "These are your settings for some app feature.",
-
-  "errors.noMatch.oops": "Uh-oh!",
-  "errors.noMatch.how": "How did you get to {location}?",
 
   "agreements.edit": "Edit",
 
@@ -43,6 +33,15 @@
   "agreements.closeNewAgreement": "Close New Agreement dialog",
   "agreements.createAgreement": "Create Agreement",
   "agreements.updateAgreement": "Update Agreement",
-  "agreements.editAgreement": "Edit Agreement"
+  "agreements.editAgreement": "Edit Agreement",
+
+  "agreementLines.name": "Name",
+  "agreementLines.type": "Type",
+
+  "settings.general": "General",
+  "settings.general.message": "These are your general app settings.",
+  "settings.some-feature": "Some Feature",
+  "settings.some-feature.message": "These are your settings for some app feature."
+
 
 }


### PR DESCRIPTION
There are a couple of outstanding bugs with using function-type path's in a connected component's manifest: [STCON-48](https://issues.folio.org/browse/STCON-48) and [STCON-49](https://issues.folio.org/browse/STCON-49)

I'm switching these components over to use a traditional string path to avoid that, and also since it's not really necessary for our use case to have function paths - the only things we're really changing here are the `params` anyway.