### PR TITLE
Fix resultCount bug

### DIFF
--- a/src/ERM.js
+++ b/src/ERM.js
@@ -11,7 +11,6 @@ import Tabs from './components/Tabs';
 export default class Erm extends React.Component {
   static manifest = Object.freeze({
     query: {},
-    resultCount: {},
   });
 
   static propTypes = {

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -32,7 +32,7 @@ class Agreements extends React.Component {
       },
     },
     query: {},
-    resultCount: {},
+    resultCount: { initialValue: INITIAL_RESULT_COUNT },
   });
 
   static propTypes = {

--- a/src/routes/KBs.js
+++ b/src/routes/KBs.js
@@ -41,7 +41,7 @@ export default class KBs extends React.Component {
       },
     },
     query: {},
-    resultCount: { },
+    resultCount: { initialValue: INITIAL_RESULT_COUNT },
   });
 
   static propTypes = {

--- a/src/routes/Titles.js
+++ b/src/routes/Titles.js
@@ -47,9 +47,7 @@ export default class Titles extends React.Component {
         filters: '',
       }
     },
-    resultCount: {
-      initialValue: INITIAL_RESULT_COUNT,
-    },
+    resultCount: { initialValue: INITIAL_RESULT_COUNT },
   });
 
   static propTypes = {


### PR DESCRIPTION
`ERM` defining the `resultCount` resource at the top level initialized it before `SearchAndSort` in the various route components could. Removed it from `ERM` and let the routes initialise it themselves.