### PR TITLE
Added generic query param generator for SAS record fetching

### DIFF
--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -5,6 +5,7 @@ import { SearchAndSort } from '@folio/stripes-smart-components';
 
 import ViewAgreement from '../components/Agreements/ViewAgreement';
 import EditAgreement from '../components/Agreements/EditAgreement';
+import getSASParams from '../util/getSASParams';
 import packageInfo from '../../package';
 
 const INITIAL_RESULT_COUNT = 100;
@@ -16,20 +17,9 @@ class Agreements extends React.Component {
       path: 'erm/sas',
       resourceShouldRefresh: true,
       records: 'results',
-      params: (queryParams, pathComponents, resources) => {
-        const params = {
-          stats: 'true',
-        };
-
-        const { query: { query, filters, sort } } = resources;
-
-        if (query) {
-          params.match = ['name', 'description'];
-          params.term = query;
-        }
-
-        return params;
-      },
+      params: getSASParams({
+        searchKey: ['name', 'description']
+      }),
     },
     query: {},
     resultCount: {},

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -18,7 +18,16 @@ class Agreements extends React.Component {
       resourceShouldRefresh: true,
       records: 'results',
       params: getSASParams({
-        searchKey: ['name', 'description']
+        searchKey: 'name',
+        columnMap: {
+          'Agreement name': 'name',
+          'Vendor': 'vendor',
+          'Start date': 'startDate',
+          'End date': 'endDate',
+          'Cancellation deadline': 'cancellationDeadline',
+          'Agreement status': 'agreementStatus',
+          'Last updated': 'lastUpdated',
+        }
       }),
     },
     agreementTypeValues: {

--- a/src/routes/KBs.js
+++ b/src/routes/KBs.js
@@ -5,6 +5,7 @@ import { get } from 'lodash';
 import { SearchAndSort } from '@folio/stripes-smart-components';
 
 import ViewKB from '../components/KBs/ViewKB';
+import getSASParams from '../util/getSASParams';
 import packageInfo from '../../package';
 
 const INITIAL_RESULT_COUNT = 100;
@@ -25,20 +26,9 @@ export default class KBs extends React.Component {
       type: 'okapi',
       resourceShouldRefresh: true,
       records: 'results',
-      params: (queryParams, pathComponents, resources) => {
-        const params = {
-          stats: 'true',
-        };
-
-        const { query: { query, filters, sort } } = resources;
-
-        if (query) {
-          params.match = 'pti.titleInstance.title';
-          params.term = query;
-        }
-
-        return params;
-      },
+      params: getSASParams({
+        searchKey: 'pti.titleInstance.title'
+      }),
     },
     query: {},
     resultCount: { },

--- a/src/routes/Titles.js
+++ b/src/routes/Titles.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { SearchAndSort } from '@folio/stripes-smart-components';
 
 import ViewTitle from '../components/Titles/ViewTitle';
+import getSASParams from '../util/getSASParams';
 import packageInfo from '../../package';
 
 const INITIAL_RESULT_COUNT = 100;
@@ -26,20 +27,9 @@ export default class Titles extends React.Component {
       path: 'erm/titles',
       recordsRequired: '%{resultCount}',
       perRequest: 100,
-      GET: {
-        params: (queryParams, pathComponents, resources) => {
-          const params = {
-            stats: 'true',
-          };
-
-          if (resources && resources.query && resources.query.query) {
-            params.match = 'title';
-            params.term = resources.query.query;
-          }
-
-          return params;
-        },
-      },
+      params: getSASParams({
+        searchKey: 'title'
+      }),
     },
     query: {
       initialValue: {

--- a/src/util/getSASParams.js
+++ b/src/util/getSASParams.js
@@ -1,5 +1,8 @@
 export default (options) => (queryParams, pathComponents, resources) => {
-  const { searchKey = '' } = options;
+  const {
+    searchKey = '',
+    columnMap = {},
+  } = options;
 
   const params = {
     stats: 'true',
@@ -16,8 +19,9 @@ export default (options) => (queryParams, pathComponents, resources) => {
     params.sort = sort.split(',').map(sortKey => {
       const descending = sortKey.startsWith('-');
       const term = sortKey.replace('-', '');
+      const key = columnMap[term] || term;
 
-      return `${term};${descending ? 'desc' : 'asc'}`;
+      return `${key};${descending ? 'desc' : 'asc'}`;
     });
   }
 

--- a/src/util/getSASParams.js
+++ b/src/util/getSASParams.js
@@ -1,0 +1,25 @@
+export default (options) => (queryParams, pathComponents, resources) => {
+  const { searchKey = '' } = options;
+
+  const params = {
+    stats: 'true',
+  };
+
+  const { query: { query, filters, sort } } = resources;
+
+  if (query) {
+    params.match = searchKey;
+    params.term = query;
+  }
+
+  if (sort) {
+    params.sort = sort.split(',').map(sortKey => {
+      const descending = sortKey.startsWith('-');
+      const term = sortKey.replace('-', '');
+
+      return `${term};${descending ? 'desc' : 'asc'}`;
+    });
+  }
+
+  return params;
+};


### PR DESCRIPTION
Refactored query param generation; it's now all done in `getSASParams.js`. 

Text searching continues to work, and I added sorting of columns as well. Sorting is not i18n-friendly atm due to [this bug on SearchAndSort](https://issues.folio.org/browse/STSMACOM-93). SAS will be rejigged in the next month or two so hopefully this will get fixed during that.