### PR TITLE
Move to `stripes` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/erm",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "ERM functionality for Stripes",
   "main": "src/index.js",
   "repository": "",
@@ -16,16 +16,12 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes-cli": "^1.4.0",
-    "@folio/stripes-logger": "^0.0.2",
+    "@folio/stripes-cli": "^1.5.0",
+    "@folio/stripes": "^1.0.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^5.5.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^3.1.0",
-    "@folio/stripes-connect": "^3.2.0",
-    "@folio/stripes-form": "^1.0.0",
-    "@folio/stripes-smart-components": "^1.8.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react-intl": "^2.4.0",
@@ -33,7 +29,7 @@
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes-core": "^2.12.0",
+    "@folio/stripes": "^1.0.0",
     "react": "*"
   },
   "stripes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/erm",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "ERM functionality for Stripes",
   "main": "src/index.js",
   "repository": "",

--- a/src/ERM.js
+++ b/src/ERM.js
@@ -11,6 +11,7 @@ import Tabs from './components/Tabs';
 export default class Erm extends React.Component {
   static manifest = Object.freeze({
     query: {},
+    resultCount: { initialValue: 0 }
   });
 
   static propTypes = {

--- a/src/components/Agreements/AgreementForm/AgreementForm.js
+++ b/src/components/Agreements/AgreementForm/AgreementForm.js
@@ -10,7 +10,7 @@ import {
   Select,
   TextArea,
   TextField,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 class AgreementForm extends React.Component {
   static propTypes = {

--- a/src/components/Agreements/EditAgreement/EditAgreement.js
+++ b/src/components/Agreements/EditAgreement/EditAgreement.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import stripesForm from '@folio/stripes-form';
-import { Button, IconButton, Pane, PaneMenu } from '@folio/stripes-components';
+import stripesForm from '@folio/stripes/form';
+import { Button, IconButton, Pane, PaneMenu } from '@folio/stripes/components';
 
 import AgreementForm from '../AgreementForm';
 

--- a/src/components/Agreements/ViewAgreement/Sections/AgreementInfo.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AgreementInfo.js
@@ -7,7 +7,7 @@ import {
   Col,
   KeyValue,
   Row,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import css from './AgreementInfo.css';
 

--- a/src/components/Agreements/ViewAgreement/Sections/AgreementLines.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AgreementLines.js
@@ -6,7 +6,7 @@ import {
   Col,
   MultiColumnList,
   Row,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 class AgreementLines extends React.Component {
   static propTypes = {

--- a/src/components/Agreements/ViewAgreement/Sections/AssociatedAgreements.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AssociatedAgreements.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion } from '@folio/stripes-components';
+import { Accordion } from '@folio/stripes/components';
 
 class AssociatedAgreements extends React.Component {
   static propTypes = {

--- a/src/components/Agreements/ViewAgreement/Sections/Eresources.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Eresources.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion } from '@folio/stripes-components';
+import { Accordion } from '@folio/stripes/components';
 
 class Eresources extends React.Component {
   static propTypes = {

--- a/src/components/Agreements/ViewAgreement/Sections/License.js
+++ b/src/components/Agreements/ViewAgreement/Sections/License.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion } from '@folio/stripes-components';
+import { Accordion } from '@folio/stripes/components';
 
 class License extends React.Component {
   static propTypes = {

--- a/src/components/Agreements/ViewAgreement/Sections/LicenseBusinessTerms.js
+++ b/src/components/Agreements/ViewAgreement/Sections/LicenseBusinessTerms.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion } from '@folio/stripes-components';
+import { Accordion } from '@folio/stripes/components';
 
 class LicenseBusinessTerms extends React.Component {
   static propTypes = {

--- a/src/components/Agreements/ViewAgreement/Sections/Organizations.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Organizations.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion } from '@folio/stripes-components';
+import { Accordion } from '@folio/stripes/components';
 
 class Organizations extends React.Component {
   static propTypes = {

--- a/src/components/Agreements/ViewAgreement/Sections/VendorInfo.js
+++ b/src/components/Agreements/ViewAgreement/Sections/VendorInfo.js
@@ -9,7 +9,7 @@ import {
   Icon,
   KeyValue,
   Row,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import css from './VendorInfo.css';
 

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -11,7 +11,7 @@ import {
   Layout,
   Pane,
   Row,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import {
   AgreementInfo,

--- a/src/components/KBs/ViewKB/ViewKB.js
+++ b/src/components/KBs/ViewKB/ViewKB.js
@@ -6,7 +6,7 @@ import {
   Icon,
   Layout,
   Pane,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 export default class ViewKB extends React.Component {
   static manifest = Object.freeze({

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Button, SegmentedControl } from '@folio/stripes-components';
+import { Button, SegmentedControl } from '@folio/stripes/components';
 
 import css from './Tabs.css';
 

--- a/src/components/Titles/ViewTitle/ViewTitle.js
+++ b/src/components/Titles/ViewTitle/ViewTitle.js
@@ -6,7 +6,7 @@ import {
   Icon,
   Layout,
   Pane,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 export default class ViewTitle extends React.Component {
   static manifest = Object.freeze({

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
-import { SearchAndSort } from '@folio/stripes-smart-components';
+import { SearchAndSort } from '@folio/stripes/smart-components';
 
 import ViewAgreement from '../components/Agreements/ViewAgreement';
 import EditAgreement from '../components/Agreements/EditAgreement';

--- a/src/routes/KBs.js
+++ b/src/routes/KBs.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
-import { SearchAndSort } from '@folio/stripes-smart-components';
+import { SearchAndSort } from '@folio/stripes/smart-components';
 
 import ViewKB from '../components/KBs/ViewKB';
 import getSASParams from '../util/getSASParams';

--- a/src/routes/Titles.js
+++ b/src/routes/Titles.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { SearchAndSort } from '@folio/stripes-smart-components';
+import { SearchAndSort } from '@folio/stripes/smart-components';
 
 import ViewTitle from '../components/Titles/ViewTitle';
 import getSASParams from '../util/getSASParams';

--- a/src/settings/general-settings.js
+++ b/src/settings/general-settings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Pane from '@folio/stripes-components/lib/Pane';
+import { Pane } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
 export default class GeneralSettings extends React.Component {

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Settings from '@folio/stripes-components/lib/Settings';
+import { Settings } from '@folio/stripes/components';
 import GeneralSettings from './general-settings';
 import SomeFeatureSettings from './some-feature-settings';
 

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Settings } from '@folio/stripes/components';
+import { Settings } from '@folio/stripes/smart-components';
 import GeneralSettings from './general-settings';
 import SomeFeatureSettings from './some-feature-settings';
 

--- a/src/settings/some-feature-settings.js
+++ b/src/settings/some-feature-settings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Pane from '@folio/stripes-components/lib/Pane';
+import { Pane } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
 export default class FeatureSettings extends React.Component {


### PR DESCRIPTION
Previously, Folio modules would depend on separate stripes modules such as `stripes-components`, `stripes-connect` and `stripes-smart-components`. Now, a new [`stripes` module](https://github.com/folio-org/stripes) groups them all to ensure consistency and compatibility.

Included in this change is an invisible bump of stripes-components from v3 to v4.