### PR TITLE
Switched components to direct dep on react-intl where possible

### DIFF
--- a/src/components/Agreements/ViewAgreement/Sections/AgreementInfo.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AgreementInfo.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { get } from 'lodash';
 import {
   Accordion,
@@ -17,7 +18,7 @@ class AgreementInfo extends React.Component {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    stripes: PropTypes.object,
+    intl: intlShape,
   };
 
   state = {
@@ -39,7 +40,7 @@ class AgreementInfo extends React.Component {
   }
 
   render() {
-    const { agreement, stripes: { intl } } = this.props;
+    const { agreement, intl } = this.props;
 
     return (
       <Accordion
@@ -127,4 +128,4 @@ class AgreementInfo extends React.Component {
   }
 }
 
-export default AgreementInfo;
+export default injectIntl(AgreementInfo);

--- a/src/components/Agreements/ViewAgreement/Sections/AssociatedAgreements.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AssociatedAgreements.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { Accordion } from '@folio/stripes/components';
 
 class AssociatedAgreements extends React.Component {
@@ -8,11 +9,11 @@ class AssociatedAgreements extends React.Component {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    stripes: PropTypes.object,
+    intl: intlShape,
   };
 
   render() {
-    const { agreement, stripes: { intl } } = this.props;
+    const { agreement, intl } = this.props;
 
     return (
       <Accordion
@@ -27,4 +28,4 @@ class AssociatedAgreements extends React.Component {
   }
 }
 
-export default AssociatedAgreements;
+export default injectIntl(AssociatedAgreements);

--- a/src/components/Agreements/ViewAgreement/Sections/Eresources.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Eresources.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { Accordion } from '@folio/stripes/components';
 
 class Eresources extends React.Component {
@@ -8,11 +9,11 @@ class Eresources extends React.Component {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    stripes: PropTypes.object,
+    intl: intlShape,
   };
 
   render() {
-    const { agreement, stripes: { intl } } = this.props;
+    const { agreement, intl } = this.props;
 
     return (
       <Accordion
@@ -27,4 +28,4 @@ class Eresources extends React.Component {
   }
 }
 
-export default Eresources;
+export default injectIntl(Eresources);

--- a/src/components/Agreements/ViewAgreement/Sections/License.js
+++ b/src/components/Agreements/ViewAgreement/Sections/License.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { Accordion } from '@folio/stripes/components';
 
 class License extends React.Component {
@@ -8,11 +9,11 @@ class License extends React.Component {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    stripes: PropTypes.object,
+    intl: intlShape,
   };
 
   render() {
-    const { agreement, stripes: { intl } } = this.props;
+    const { agreement, intl } = this.props;
 
     return (
       <Accordion
@@ -27,4 +28,4 @@ class License extends React.Component {
   }
 }
 
-export default License;
+export default injectIntl(License);

--- a/src/components/Agreements/ViewAgreement/Sections/LicenseBusinessTerms.js
+++ b/src/components/Agreements/ViewAgreement/Sections/LicenseBusinessTerms.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { Accordion } from '@folio/stripes/components';
 
 class LicenseBusinessTerms extends React.Component {
@@ -8,11 +9,11 @@ class LicenseBusinessTerms extends React.Component {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    stripes: PropTypes.object,
+    intl: intlShape,
   };
 
   render() {
-    const { agreement, stripes: { intl } } = this.props;
+    const { agreement, intl } = this.props;
 
     return (
       <Accordion
@@ -27,4 +28,4 @@ class LicenseBusinessTerms extends React.Component {
   }
 }
 
-export default LicenseBusinessTerms;
+export default injectIntl(LicenseBusinessTerms);

--- a/src/components/Agreements/ViewAgreement/Sections/Organizations.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Organizations.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { Accordion } from '@folio/stripes/components';
 
 class Organizations extends React.Component {
@@ -8,11 +9,11 @@ class Organizations extends React.Component {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    stripes: PropTypes.object,
+    intl: intlShape,
   };
 
   render() {
-    const { agreement, stripes: { intl } } = this.props;
+    const { agreement, intl } = this.props;
 
     return (
       <Accordion
@@ -27,4 +28,4 @@ class Organizations extends React.Component {
   }
 }
 
-export default Organizations;
+export default injectIntl(Organizations);

--- a/src/components/EResources/ViewEResource/Sections/AcquisitionOptions.js
+++ b/src/components/EResources/ViewEResource/Sections/AcquisitionOptions.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import {
   Accordion,
   Col,
@@ -13,11 +14,11 @@ class AcquisitionOptions extends React.Component {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    stripes: PropTypes.object,
+    intl: intlShape,
   };
 
   render() {
-    const { eresource, stripes: { intl } } = this.props;
+    const { eresource, intl } = this.props;
 
     return (
       <Accordion
@@ -36,4 +37,4 @@ class AcquisitionOptions extends React.Component {
   }
 }
 
-export default AcquisitionOptions;
+export default injectIntl(AcquisitionOptions);

--- a/src/components/EResources/ViewEResource/Sections/EResourceInfo.js
+++ b/src/components/EResources/ViewEResource/Sections/EResourceInfo.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import {
   Accordion,
   Col,
@@ -14,11 +15,11 @@ class EResourceInfo extends React.Component {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    stripes: PropTypes.object,
+    intl: intlShape,
   };
 
   render() {
-    const { eresource, stripes: { intl } } = this.props;
+    const { eresource, intl } = this.props;
 
     return (
       <Accordion
@@ -40,4 +41,4 @@ class EResourceInfo extends React.Component {
   }
 }
 
-export default EResourceInfo;
+export default injectIntl(EResourceInfo);


### PR DESCRIPTION
Basically just minimizing our dependence on the `stripes` prop. If we're only consuming the `intl` part of `stripes`, we can get that directly from `react-intl`. 

I can't convert all our usage to this just yet because stripes-connected components have issues with injected `intl`. The argument can be made that we should split up any component that requires both `intl` and `connect` into presentation and container components, but that's not a job for today.