### PR TITLE
E-resources: Update paths and list agreements

### DIFF
--- a/src/ERM.js
+++ b/src/ERM.js
@@ -7,10 +7,12 @@ import Agreements from './routes/Agreements';
 import EResources from './routes/EResources';
 import Tabs from './components/Tabs';
 
+const INITIAL_RESULT_COUNT = 100;
+
 export default class Erm extends React.Component {
   static manifest = Object.freeze({
     query: {},
-    resultCount: { initialValue: 0 }
+    resultCount: { initialValue: INITIAL_RESULT_COUNT }
   });
 
   static propTypes = {

--- a/src/components/EResources/ViewEResource/Sections/EResourceAgreements.js
+++ b/src/components/EResources/ViewEResource/Sections/EResourceAgreements.js
@@ -57,14 +57,6 @@ class EResourceAgreements extends React.Component {
               package: intl.formatMessage({ id: 'ui-erm.eresources.parentPackage' }),
               acqMethod: intl.formatMessage({ id: 'ui-erm.eresources.acqMethod' }),
             }}
-            // columnWidths={{
-            //   name:,
-            //   type:,
-            //   startDate:,
-            //   endDate:,
-            //   package:,
-            //   acqMethod:,
-            // }}
           />
         </Col>
       </Row>

--- a/src/components/EResources/ViewEResource/Sections/EResourceAgreements.js
+++ b/src/components/EResources/ViewEResource/Sections/EResourceAgreements.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
 import {
-  Accordion,
   Col,
   Icon,
   MultiColumnList,
@@ -12,80 +11,63 @@ import {
 
 class EResourceAgreements extends React.Component {
   static manifest = Object.freeze({
-    agreements: {
+    entitlements: {
       type: 'okapi',
-      path: 'erm/sas/%{agreementToFetch}',
-      fetch: false,
-      accumulate: true,
+      path: 'erm/resource/:{id}/entitlements',
+      throwErrors: false, // We can get a 404 from this endpoint
     },
-    agreementToFetch: { initialValue: '' },
   })
 
   static propTypes = {
-    eresource: PropTypes.object,
-    id: PropTypes.string,
-    mutator: PropTypes.shape({
-      agreements: PropTypes.object,
-      agreementToFetch: PropTypes.object
-    }),
-    onToggle: PropTypes.func,
-    open: PropTypes.bool,
+    match: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     resources: PropTypes.shape({
-      agreements: PropTypes.object,
-      agreementToFetch: PropTypes.string
+      entitlements: PropTypes.object,
     }),
     stripes: PropTypes.object,
   };
 
-  componentDidMount() {
-    const { mutator, eresource: { entitlements } } = this.props;
-
-    mutator.agreements.reset();
-
-    if (!entitlements || !entitlements.length) return;
-
-    entitlements.forEach((entitlement) => {
-      mutator.agreementToFetch.replace(entitlement.owner.id);
-      mutator.agreements.GET();
-    });
-  }
 
   render() {
-    const { resources: { agreements }, stripes: { intl } } = this.props;
+    const { resources: { entitlements }, stripes: { intl } } = this.props;
 
-    if (!agreements || !agreements.records) {
+    if (!entitlements || !entitlements.records) {
       return <Icon icon="spinner-ellipsis" width="100px" />;
     }
 
     return (
-      <Accordion
-        id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-erm.eresources.erInfo' })}
-        open={this.props.open}
-        onToggle={this.props.onToggle}
-      >
-        <Row>
-          <Col xs={12}>
-            <MultiColumnList
-              contentData={agreements.records}
-              maxHeight={400}
-              visibleColumns={['name', 'type']}
-              formatter={{
-                name: agreement => <Link to={`/erm/agreements/view/${agreement.id}`}>{agreement.name}</Link>,
-                type: agreement => agreement.agreementStatus && agreement.agreementStatus.label,
-              }}
-              columnMapping={{
-                name: intl.formatMessage({ id: 'ui-erm.eresources.erAgreements' }),
-                type: intl.formatMessage({ id: 'ui-erm.eresources.agreementStatus' }),
-              }}
-              columnWidths={{
-                name: '60%',
-                type: '40%',
-              }}
-            />
-          </Col>
-        </Row>
-      </Accordion>
+      <Row>
+        <Col xs={12}>
+          <MultiColumnList
+            contentData={entitlements.records}
+            maxHeight={400}
+            visibleColumns={['name', 'type', 'startDate', 'endDate', 'package', 'acqMethod']}
+            formatter={{
+              name: ({ owner }) => <Link to={`/erm/agreements/view/${owner.id}`}>{owner.name}</Link>,
+              type: ({ owner }) => owner.agreementStatus && owner.agreementStatus.label,
+              startDate: ({ owner }) => owner.startDate && intl.formatDate(owner.startDate),
+              endDate: ({ owner }) => owner.endDate && intl.formatDate(owner.endDate),
+              package: ({ resource }) => <Link to={`/erm/eresources/view/${resource.id}`}>{resource.name}</Link>,
+              acqMethod: ({ resource }) => resource.class,
+            }}
+            columnMapping={{
+              name: intl.formatMessage({ id: 'ui-erm.eresources.erAgreements' }),
+              type: intl.formatMessage({ id: 'ui-erm.eresources.agreementStatus' }),
+              startDate: intl.formatMessage({ id: 'ui-erm.agreements.startDate' }),
+              endDate: intl.formatMessage({ id: 'ui-erm.agreements.endDate' }),
+              package: intl.formatMessage({ id: 'ui-erm.eresources.parentPackage' }),
+              acqMethod: intl.formatMessage({ id: 'ui-erm.eresources.acqMethod' }),
+            }}
+            // columnWidths={{
+            //   name:,
+            //   type:,
+            //   startDate:,
+            //   endDate:,
+            //   package:,
+            //   acqMethod:,
+            // }}
+          />
+        </Col>
+      </Row>
     );
   }
 }

--- a/src/components/EResources/ViewEResource/Sections/EResourceAgreements.js
+++ b/src/components/EResources/ViewEResource/Sections/EResourceAgreements.js
@@ -47,7 +47,9 @@ class EResourceAgreements extends React.Component {
               startDate: ({ owner }) => owner.startDate && intl.formatDate(owner.startDate),
               endDate: ({ owner }) => owner.endDate && intl.formatDate(owner.endDate),
               package: ({ resource }) => <Link to={`/erm/eresources/view/${resource.id}`}>{resource.name}</Link>,
-              acqMethod: ({ resource }) => resource.class,
+              acqMethod: ({ resource }) => (resource.class === 'org.olf.kb.Pkg' ?
+                intl.formatMessage({ id: 'ui-erm.eresources.package' }) : intl.formatMessage({ id: 'ui-erm.eresources.title' })
+              ),
             }}
             columnMapping={{
               name: intl.formatMessage({ id: 'ui-erm.eresources.erAgreements' }),

--- a/src/components/EResources/ViewEResource/Sections/EResourceInfo.js
+++ b/src/components/EResources/ViewEResource/Sections/EResourceInfo.js
@@ -7,15 +7,23 @@ import {
   Row,
 } from '@folio/stripes/components';
 
+import { EResourceAgreements } from '.';
 
 class EResourceInfo extends React.Component {
   static propTypes = {
     eresource: PropTypes.object,
     id: PropTypes.string,
+    match: PropTypes.object,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
     stripes: PropTypes.object,
   };
+
+  constructor(props) {
+    super(props);
+
+    this.connectedEResourceAgreements = props.stripes.connect(EResourceAgreements);
+  }
 
   render() {
     const { eresource, stripes: { intl } } = this.props;
@@ -35,6 +43,10 @@ class EResourceInfo extends React.Component {
             />
           </Col>
         </Row>
+        <this.connectedEResourceAgreements
+          key={`agreements-${eresource.id}`} // Force a remount when changing which eresource we're viewing
+          {...this.props}
+        />
       </Accordion>
     );
   }

--- a/src/components/EResources/ViewEResource/Sections/EResourceInfo.js
+++ b/src/components/EResources/ViewEResource/Sections/EResourceInfo.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import {
   Accordion,
   Col,
@@ -25,6 +26,17 @@ class EResourceInfo extends React.Component {
     this.connectedEResourceAgreements = props.stripes.connect(EResourceAgreements);
   }
 
+  getIdentifier(type) {
+    const { eresource: { identifiers } } = this.props;
+
+    if (!Array.isArray(identifiers) || !identifiers.length) return '-';
+
+    const entry = identifiers.find(i => i.identifier.ns.value === type);
+    if (!entry) return '-';
+
+    return entry.identifier.value;
+  }
+
   render() {
     const { eresource, stripes: { intl } } = this.props;
 
@@ -39,7 +51,25 @@ class EResourceInfo extends React.Component {
           <Col xs={4}>
             <KeyValue
               label={intl.formatMessage({ id: 'ui-erm.eresources.erType' })}
-              value={(eresource.type && eresource.type.label) || '-'}
+              value={get(eresource, ['type', 'label'], '-')}
+            />
+          </Col>
+          <Col xs={4}>
+            <KeyValue
+              label={intl.formatMessage({ id: 'ui-erm.eresources.publisher' })}
+              value={get(eresource, ['publisher', 'label'], '-')}
+            />
+          </Col>
+          <Col xs={2}>
+            <KeyValue
+              label={intl.formatMessage({ id: 'ui-erm.eresources.pIssn' })}
+              value={this.getIdentifier('pissn')}
+            />
+          </Col>
+          <Col xs={2}>
+            <KeyValue
+              label={intl.formatMessage({ id: 'ui-erm.eresources.eIssn' })}
+              value={this.getIdentifier('eissn')}
             />
           </Col>
         </Row>

--- a/src/components/EResources/ViewEResource/ViewEResource.js
+++ b/src/components/EResources/ViewEResource/ViewEResource.js
@@ -77,7 +77,7 @@ class ViewEResource extends React.Component {
     return (
       <Pane
         id="pane-view-eresource"
-        defaultWidth={this.props.paneWidth}
+        defaultWidth="55%"
         paneTitle="Loading..."
         dismissible
         onClose={this.props.onClose}
@@ -98,7 +98,7 @@ class ViewEResource extends React.Component {
     return (
       <Pane
         id="pane-view-eresource"
-        defaultWidth={this.props.paneWidth}
+        defaultWidth="55%"
         paneTitle={resource.name}
         dismissible
         onClose={this.props.onClose}

--- a/src/components/EResources/ViewEResource/ViewEResource.js
+++ b/src/components/EResources/ViewEResource/ViewEResource.js
@@ -22,7 +22,7 @@ class ViewEResource extends React.Component {
   static manifest = Object.freeze({
     selectedEResource: {
       type: 'okapi',
-      path: 'erm/eresources/:{id}',
+      path: 'erm/resource/:{id}',
     },
     query: {},
   });

--- a/src/components/EResources/ViewEResource/ViewEResource.js
+++ b/src/components/EResources/ViewEResource/ViewEResource.js
@@ -14,7 +14,6 @@ import {
 
 import {
   EResourceInfo,
-  EResourceAgreements,
   AcquisitionOptions,
 } from './Sections';
 
@@ -45,8 +44,6 @@ class ViewEResource extends React.Component {
         acquisitionOptions: false,
       }
     };
-
-    this.connectedEResourceAgreements = props.stripes.connect(EResourceAgreements);
   }
 
   getEResource() {
@@ -56,6 +53,7 @@ class ViewEResource extends React.Component {
 
   getSectionProps() {
     return {
+      match: this.props.match,
       eresource: this.getEResource(),
       onToggle: this.handleSectionToggle,
       stripes: this.props.stripes,
@@ -114,12 +112,6 @@ class ViewEResource extends React.Component {
           <EResourceInfo
             id="info"
             open={this.state.sections.info}
-            {...sectionProps}
-          />
-          <this.connectedEResourceAgreements
-            id="agreements"
-            key={`agreements-${resource.id}`} // Force a remount when changing which eresource we're viewing
-            open={this.state.sections.agreements}
             {...sectionProps}
           />
           <AcquisitionOptions

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -26,6 +26,9 @@ class Agreements extends React.Component {
       path: 'erm/sas',
       resourceShouldRefresh: true,
       records: 'results',
+      recordsRequired: '%{resultCount}',
+      perRequest: 100,
+      limitParam: 'perPage',
       params: getSASParams({
         searchKey: 'name',
         columnMap: {

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -101,6 +101,8 @@ class Agreements extends React.Component {
         config.values = records[i].map(r => ({ name: r.label, cql: r.value }));
         config.label = intl.formatMessage({ id: `ui-erm.agreements.${filter}` });
       });
+
+      this.props.stripes.logger.log('erm', 'Filter Config Updated', filterConfig);
     }
   }
 

--- a/src/routes/EResources.js
+++ b/src/routes/EResources.js
@@ -13,9 +13,12 @@ class EResources extends React.Component {
   static manifest = Object.freeze({
     records: {
       type: 'okapi',
-      path: 'erm/eresources',
+      path: 'erm/resource/electronic',
       resourceShouldRefresh: true,
       records: 'results',
+      recordsRequired: '%{resultCount}',
+      perRequest: 100,
+      limitParam: 'perPage',
       params: getSASParams({
         searchKey: 'name',
         columnMap: {

--- a/translations/ui-erm/en.json
+++ b/translations/ui-erm/en.json
@@ -58,6 +58,8 @@
   "eresources.erAgreements": "Agreements for this e-resource",
   "eresources.agreementStatus": "Agreement status",
   "eresources.acqOptions": "Options for acquiring e-resource: {name}",
+  "eresources.parentPackage": "Parent package",
+  "eresources.acqMethod": "Acquisition method",
 
   "settings.general": "General",
   "settings.general.message": "These are your general app settings.",

--- a/translations/ui-erm/en.json
+++ b/translations/ui-erm/en.json
@@ -56,6 +56,8 @@
   "eresources.erInfo": "E-resource information",
   "eresources.erType": "E-resource type",
   "eresources.publisher": "Publisher",
+  "eresources.package": "Package",
+  "eresources.title": "Title",
   "eresources.pIssn": "ISSN (Print)",
   "eresources.eIssn": "ISSN (Online)",
   "eresources.jusp": "JUSP",

--- a/translations/ui-erm/en.json
+++ b/translations/ui-erm/en.json
@@ -55,6 +55,10 @@
 
   "eresources.erInfo": "E-resource information",
   "eresources.erType": "E-resource type",
+  "eresources.publisher": "Publisher",
+  "eresources.pIssn": "ISSN (Print)",
+  "eresources.eIssn": "ISSN (Online)",
+  "eresources.jusp": "JUSP",
   "eresources.erAgreements": "Agreements for this e-resource",
   "eresources.agreementStatus": "Agreement status",
   "eresources.acqOptions": "Options for acquiring e-resource: {name}",


### PR DESCRIPTION
- Updated the E-resources section to the new `/erm/resource/*` paths.
- Fixed a paging bug.
  - Query params specify `perPage` again and use the `offset` param rather than the `page` param.
- In the E-resource details pane, show the agreements for the selected e-resource.
  - Using the new `/erm/resource/{id}/entitlements` path
  - Questions for @sosguthorpe:
    - Do you know if **Acquisition method** should be `entitlement.resource.class === 'org.olf.kb.Pkg' ? 'Package' : 'Item'` [for/based on Scenario 2 here](https://issues.folio.org/browse/UIER-21).
    - Some items returned from `/erm/resource/electronic` return a 404 when I look up their `/entitlements`. Should they be returning an empty array? E.g., the "American Psychological Association:Master" resource. Are they just anomalies of sample data?